### PR TITLE
Improved NULL check, nulled `bus_data`, clear some status variables during init

### DIFF
--- a/drivers/staging/wilc1000/bt.c
+++ b/drivers/staging/wilc1000/bt.c
@@ -307,7 +307,7 @@ int wilc_bt_power_down(struct wilc *wilc, int source)
 
 	mutex_lock(&wilc->cs);
 
-	pr_info("source: %s, current bus status Wifi: %d, BT: %d\n",
+	pr_info("POWERING DOWN: source: %s, current bus status Wifi: %d, BT: %d\n",
 		 (source == DEV_WIFI ? "Wifi" : "BT"),
 		 wilc->power.status[DEV_WIFI],
 		 wilc->power.status[DEV_BT]);
@@ -327,6 +327,7 @@ int wilc_bt_power_down(struct wilc *wilc, int source)
 		release_bus(wilc, WILC_BUS_RELEASE_ONLY, source);
 		if (ret) {
 			mutex_unlock(&wilc->cs);
+			pr_err("deinit failed ret: 0x%0x\n", ret);
 			return ret;
 		}
 	}
@@ -346,7 +347,7 @@ int wilc_bt_power_up(struct wilc *wilc, int source)
 
 	mutex_lock(&wilc->cs);
 
-	pr_debug("source: %s, current bus status Wifi: %d, BT: %d\n",
+	pr_info("POWERING UP: source: %s, current bus status Wifi: %d, BT: %d\n",
 		 (source == DEV_WIFI ? "Wifi" : "BT"),
 		 wilc->power.status[DEV_WIFI],
 		 wilc->power.status[DEV_BT]);

--- a/drivers/staging/wilc1000/debugfs.c
+++ b/drivers/staging/wilc1000/debugfs.c
@@ -9,9 +9,8 @@
 
 #include "debugfs.h"
 
-atomic_t WILC_DEBUG_REGION = ATOMIC_INIT(INIT_DBG | GENERIC_DBG |
-					 CFG80211_DBG | HOSTAPD_DBG |
-					 PWRDEV_DBG);
+atomic_t WILC_DEBUG_REGION = ATOMIC_INIT(INIT_DBG | GENERIC_DBG | CFG80211_DBG | HOSTAPD_DBG | PWRDEV_DBG | CORECONFIG_DBG);
+
 #if KERNEL_VERSION(3, 15, 0) > LINUX_VERSION_CODE
 /**
  * of_irq_parse_raw - Low level interrupt tree parsing

--- a/drivers/staging/wilc1000/debugfs.c
+++ b/drivers/staging/wilc1000/debugfs.c
@@ -9,8 +9,9 @@
 
 #include "debugfs.h"
 
-atomic_t WILC_DEBUG_REGION = ATOMIC_INIT(INIT_DBG | GENERIC_DBG | CFG80211_DBG | HOSTAPD_DBG | PWRDEV_DBG | CORECONFIG_DBG);
-
+atomic_t WILC_DEBUG_REGION = ATOMIC_INIT(INIT_DBG | GENERIC_DBG |
+					 CFG80211_DBG | HOSTAPD_DBG |
+					 PWRDEV_DBG);
 #if KERNEL_VERSION(3, 15, 0) > LINUX_VERSION_CODE
 /**
  * of_irq_parse_raw - Low level interrupt tree parsing

--- a/drivers/staging/wilc1000/hif.c
+++ b/drivers/staging/wilc1000/hif.c
@@ -1819,10 +1819,16 @@ int wilc_get_rssi(struct wilc_vif *vif, s8 *rssi_level)
 {
 	struct wid wid;
 	int result;
+	struct wilc *wilc = vif->wilc;
 
 	if (!rssi_level) {
 		PRINT_ER(vif->ndev, "RSS pointer value is null\n");
 		return -EFAULT;
+	}
+
+	if (!wilc->initialized) {
+		netdev_info(vif->ndev, "Driver not initialized\n");
+		return 0;
 	}
 
 	wid.id = WID_RSSI;

--- a/drivers/staging/wilc1000/netdev.c
+++ b/drivers/staging/wilc1000/netdev.c
@@ -20,10 +20,6 @@
 
 #define WILC_MULTICAST_TABLE_SIZE	8
 
-#define INIT_TIMEOUT   300
-#define DEINIT_TIMEOUT 10000
-
-
 static int wilc_mac_open(struct net_device *ndev);
 static int wilc_mac_close(struct net_device *ndev);
 
@@ -793,10 +789,6 @@ static void wilc_wlan_deinitialize(struct net_device *dev)
 	} else {
 		PRINT_INFO(dev, INIT_DBG, "wilc is not initialized\n");
 	}
-
-        pr_info("%s: Will sleep a bit after deinitialize\n", __func__);
-        msleep(DEINIT_TIMEOUT);
-
 }
 
 static int wlan_initialize_threads(struct net_device *dev)
@@ -837,9 +829,6 @@ static int wilc_wlan_initialize(struct net_device *dev, struct wilc_vif *vif)
 {
 	int ret = 0;
 	struct wilc *wl = vif->wilc;
-
-        pr_info("%s: Will sleep a bit before initialize\n", __func__);
-        msleep(INIT_TIMEOUT);
 
 	if (!wl->initialized) {
 		wl->mac_status = WILC_MAC_STATUS_INIT;

--- a/drivers/staging/wilc1000/netdev.c
+++ b/drivers/staging/wilc1000/netdev.c
@@ -750,9 +750,12 @@ static void wilc_wlan_deinitialize(struct net_device *dev)
 		return;
 	}
 
-
 	if (wl->initialized) {
 		PRINT_INFO(vif->ndev, INIT_DBG, "Deinitializing wilc  ...\n");
+
+		ret = wilc_wlan_stop(wl, vif);
+		if (ret != 0)
+			PRINT_ER(dev, "failed in wlan_stop\n");
 
 		PRINT_D(vif->ndev, INIT_DBG, "destroy aging timer\n");
 
@@ -767,16 +770,11 @@ static void wilc_wlan_deinitialize(struct net_device *dev)
 				mutex_unlock(&wl->hif_cs);
 			}
 		}
-		complete(&wl->txq_event);
+		deinit_irq(dev);
 
 		PRINT_INFO(vif->ndev, INIT_DBG, "Deinitializing Threads\n");
 		wlan_deinitialize_threads(dev);
 		PRINT_INFO(vif->ndev, INIT_DBG, "Deinitializing IRQ\n");
-		deinit_irq(dev);
-
-		ret = wilc_wlan_stop(wl, vif);
-		if (ret != 0)
-			PRINT_ER(dev, "failed in wlan_stop\n");
 
 		PRINT_INFO(vif->ndev, INIT_DBG, "Deinitializing WILC Wlan\n");
 		wilc_wlan_cleanup(dev);

--- a/drivers/staging/wilc1000/netdev.c
+++ b/drivers/staging/wilc1000/netdev.c
@@ -832,9 +832,6 @@ static int wilc_wlan_initialize(struct net_device *dev, struct wilc_vif *vif)
 
 	if (!wl->initialized) {
 		wl->mac_status = WILC_MAC_STATUS_INIT;
-		wl->close = 0;
-		wl->quit = 0;
-		wl->initialized = 0;
 
 		ret = wilc_wlan_init(dev);
 		if (ret) {

--- a/drivers/staging/wilc1000/netdev.c
+++ b/drivers/staging/wilc1000/netdev.c
@@ -786,6 +786,8 @@ static void wilc_wlan_deinitialize(struct net_device *dev)
 		wilc_wlan_cleanup(dev);
 
 		wl->initialized = false;
+		wl->close = 0;
+		wl->quit = 0;
 
 		PRINT_INFO(dev, INIT_DBG, "wilc deinitialization Done\n");
 	} else {
@@ -842,6 +844,7 @@ static int wilc_wlan_initialize(struct net_device *dev, struct wilc_vif *vif)
 	if (!wl->initialized) {
 		wl->mac_status = WILC_MAC_STATUS_INIT;
 		wl->close = 0;
+		wl->quit = 0;
 		wl->initialized = 0;
 
 		ret = wilc_wlan_init(dev);

--- a/drivers/staging/wilc1000/netdev.c
+++ b/drivers/staging/wilc1000/netdev.c
@@ -1192,6 +1192,9 @@ static int wilc_mac_close(struct net_device *ndev)
 		wl->close = 1;
 
 		wilc_wlan_deinitialize(ndev);
+
+		PRINT_INFO(ndev, GENERIC_DBG, "Powering down wilc\n");
+		wilc_bt_power_down(wl, DEV_WIFI);
 	}
 
 	vif->mac_opened = 0;

--- a/drivers/staging/wilc1000/netdev.c
+++ b/drivers/staging/wilc1000/netdev.c
@@ -911,6 +911,7 @@ fail_threads:
 fail_wilc_wlan:
 		wilc_wlan_cleanup(dev);
 		PRINT_ER(dev, "WLAN initialization FAILED\n");
+		wl->initialized = false;
 	} else {
 		PRINT_WRN(vif->ndev, INIT_DBG, "wilc already initialized\n");
 	}

--- a/drivers/staging/wilc1000/sdio.c
+++ b/drivers/staging/wilc1000/sdio.c
@@ -415,12 +415,12 @@ static int wilc_sdio_write_reg(struct wilc *wilc, u32 addr, u32 data)
 {
 	struct sdio_func *func = dev_to_sdio_func(wilc->dev);
 	struct wilc_sdio *sdio_priv = wilc->bus_data;
+	int ret;
+
 	if (!sdio_priv) {
-		dev_err(&func->dev, "%s: 'bus_data' not initialized\n", __FUNC__);
+		dev_err(&func->dev, "%s: 'bus_data' not initialized\n", __func__);
 		return -1;
 	}
-
-	int ret;
 
 	cpu_to_le32s(&data);
 
@@ -472,7 +472,7 @@ static int wilc_sdio_write(struct wilc *wilc, u32 addr, u8 *buf, u32 size)
 	struct sdio_func *func = dev_to_sdio_func(wilc->dev);
 	struct wilc_sdio *sdio_priv = wilc->bus_data;
 	if (!sdio_priv) {
-		dev_err(&func->dev, "%s: 'bus_data' not initialized\n", __FUNC__);
+		dev_err(&func->dev, "%s: 'bus_data' not initialized\n", __func__);
 		return -1;
 	}
 
@@ -549,11 +549,12 @@ static int wilc_sdio_read_reg(struct wilc *wilc, u32 addr, u32 *data)
 {
 	struct sdio_func *func = dev_to_sdio_func(wilc->dev);
 	struct wilc_sdio *sdio_priv = wilc->bus_data;
+	int ret;
+	
 	if (!sdio_priv) {
-		dev_err(&func->dev, "%s: 'bus_data' not initialized\n", __FUNC__);
+		dev_err(&func->dev, "%s: 'bus_data' not initialized\n", __func__);
 		return -1;
 	}
-	int ret;
 
 	if (addr >= 0xf0 && addr <= 0xff) { /* only vendor specific registers */
 		struct sdio_cmd52 cmd;
@@ -601,13 +602,15 @@ static int wilc_sdio_read(struct wilc *wilc, u32 addr, u8 *buf, u32 size)
 {
 	struct sdio_func *func = dev_to_sdio_func(wilc->dev);
 	struct wilc_sdio *sdio_priv = wilc->bus_data;
-	if (!sdio_priv) {
-		dev_err(&func->dev, "%s: 'bus_data' not initialized\n", __FUNC__);
-		return -1;
-	}
-	u32 block_size = sdio_priv->block_size;
 	struct sdio_cmd53 cmd;
 	int nblk, nleft, ret;
+	u32 block_size;
+
+	if (!sdio_priv) {
+		dev_err(&func->dev, "%s: 'bus_data' not initialized\n", __func__);
+		return -1;
+	}
+	block_size = sdio_priv->block_size;
 
 	cmd.read_write = 0;
 	if (addr > 0) {
@@ -700,7 +703,7 @@ static int wilc_sdio_init(struct wilc *wilc, bool resume)
 	struct sdio_func *func = dev_to_sdio_func(wilc->dev);
 	struct wilc_sdio *sdio_priv = wilc->bus_data;
 	if (!sdio_priv) {
-		dev_err(&func->dev, "%s: 'bus_data' not initialized\n", __FUNC__);
+		dev_err(&func->dev, "%s: 'bus_data' not initialized\n", __func__);
 		return -1;
 	}
 
@@ -863,7 +866,7 @@ static int wilc_sdio_read_int(struct wilc *wilc, u32 *int_status)
 	struct sdio_func *func = dev_to_sdio_func(wilc->dev);
 	struct wilc_sdio *sdio_priv = wilc->bus_data;
 	if (!sdio_priv) {
-		dev_err(&func->dev, "%s: 'bus_data' not initialized\n", __FUNC__);
+		dev_err(&func->dev, "%s: 'bus_data' not initialized\n", __func__);
 		return -1;
 	}
 
@@ -916,13 +919,13 @@ static int wilc_sdio_clear_int_ext(struct wilc *wilc, u32 val)
 {
 	struct sdio_func *func = dev_to_sdio_func(wilc->dev);
 	struct wilc_sdio *sdio_priv = wilc->bus_data;
-	if (!sdio_priv) {
-		dev_err(&func->dev, "%s: 'bus_data' not initialized\n", __FUNC__);
-		return -1;
-	}
-
 	int ret;
 	u32 reg = 0;
+	
+	if (!sdio_priv) {
+		dev_err(&func->dev, "%s: 'bus_data' not initialized\n", __func__);
+		return -1;
+	}
 
 	if (wilc->chip == WILC_1000) {
 		if (sdio_priv->irq_gpio)
@@ -1013,7 +1016,7 @@ static int wilc_sdio_sync_ext(struct wilc *wilc, int nint)
 	struct sdio_func *func = dev_to_sdio_func(wilc->dev);
 	struct wilc_sdio *sdio_priv = wilc->bus_data;
 	if (!sdio_priv) {
-		dev_err(&func->dev, "%s: 'bus_data' not initialized\n", __FUNC__);
+		dev_err(&func->dev, "%s: 'bus_data' not initialized\n", __func__);
 		return -1;
 	}
 

--- a/drivers/staging/wilc1000/sdio.c
+++ b/drivers/staging/wilc1000/sdio.c
@@ -261,6 +261,9 @@ static int wilc_sdio_reset(struct wilc *wilc)
 static bool wilc_sdio_is_init(struct wilc *wilc)
 {
 	struct wilc_sdio *sdio_priv = wilc->bus_data;
+	if (!sdio_priv) {
+		return false;
+	}
 
 	return sdio_priv->is_init;
 }
@@ -412,6 +415,11 @@ static int wilc_sdio_write_reg(struct wilc *wilc, u32 addr, u32 data)
 {
 	struct sdio_func *func = dev_to_sdio_func(wilc->dev);
 	struct wilc_sdio *sdio_priv = wilc->bus_data;
+	if (!sdio_priv) {
+		dev_err(&func->dev, "%s: 'bus_data' not initialized\n", __FUNC__);
+		return -1;
+	}
+
 	int ret;
 
 	cpu_to_le32s(&data);
@@ -463,6 +471,11 @@ static int wilc_sdio_write(struct wilc *wilc, u32 addr, u8 *buf, u32 size)
 {
 	struct sdio_func *func = dev_to_sdio_func(wilc->dev);
 	struct wilc_sdio *sdio_priv = wilc->bus_data;
+	if (!sdio_priv) {
+		dev_err(&func->dev, "%s: 'bus_data' not initialized\n", __FUNC__);
+		return -1;
+	}
+
 	u32 block_size = sdio_priv->block_size;
 	struct sdio_cmd53 cmd;
 	int nblk, nleft, ret;
@@ -536,6 +549,10 @@ static int wilc_sdio_read_reg(struct wilc *wilc, u32 addr, u32 *data)
 {
 	struct sdio_func *func = dev_to_sdio_func(wilc->dev);
 	struct wilc_sdio *sdio_priv = wilc->bus_data;
+	if (!sdio_priv) {
+		dev_err(&func->dev, "%s: 'bus_data' not initialized\n", __FUNC__);
+		return -1;
+	}
 	int ret;
 
 	if (addr >= 0xf0 && addr <= 0xff) { /* only vendor specific registers */
@@ -584,6 +601,10 @@ static int wilc_sdio_read(struct wilc *wilc, u32 addr, u8 *buf, u32 size)
 {
 	struct sdio_func *func = dev_to_sdio_func(wilc->dev);
 	struct wilc_sdio *sdio_priv = wilc->bus_data;
+	if (!sdio_priv) {
+		dev_err(&func->dev, "%s: 'bus_data' not initialized\n", __FUNC__);
+		return -1;
+	}
 	u32 block_size = sdio_priv->block_size;
 	struct sdio_cmd53 cmd;
 	int nblk, nleft, ret;
@@ -664,7 +685,9 @@ static int wilc_sdio_deinit(struct wilc *wilc)
 	struct sdio_func *func = dev_to_sdio_func(wilc->dev);
 	struct wilc_sdio *sdio_priv = wilc->bus_data;
 
-	sdio_priv->is_init = false;
+	if (sdio_priv) {
+		sdio_priv->is_init = false;
+	}
 
 	pm_runtime_put_sync_autosuspend(mmc_dev(func->card->host));
 	wilc_wlan_power(wilc, false);
@@ -676,6 +699,11 @@ static int wilc_sdio_init(struct wilc *wilc, bool resume)
 {
 	struct sdio_func *func = dev_to_sdio_func(wilc->dev);
 	struct wilc_sdio *sdio_priv = wilc->bus_data;
+	if (!sdio_priv) {
+		dev_err(&func->dev, "%s: 'bus_data' not initialized\n", __FUNC__);
+		return -1;
+	}
+
 	struct sdio_cmd52 cmd;
 	int loop, ret;
 	u32 chipid;
@@ -834,6 +862,11 @@ static int wilc_sdio_read_int(struct wilc *wilc, u32 *int_status)
 {
 	struct sdio_func *func = dev_to_sdio_func(wilc->dev);
 	struct wilc_sdio *sdio_priv = wilc->bus_data;
+	if (!sdio_priv) {
+		dev_err(&func->dev, "%s: 'bus_data' not initialized\n", __FUNC__);
+		return -1;
+	}
+
 	u32 tmp;
 	struct sdio_cmd52 cmd;
 	u32 irq_flags;
@@ -883,6 +916,11 @@ static int wilc_sdio_clear_int_ext(struct wilc *wilc, u32 val)
 {
 	struct sdio_func *func = dev_to_sdio_func(wilc->dev);
 	struct wilc_sdio *sdio_priv = wilc->bus_data;
+	if (!sdio_priv) {
+		dev_err(&func->dev, "%s: 'bus_data' not initialized\n", __FUNC__);
+		return -1;
+	}
+
 	int ret;
 	u32 reg = 0;
 
@@ -974,6 +1012,11 @@ static int wilc_sdio_sync_ext(struct wilc *wilc, int nint)
 {
 	struct sdio_func *func = dev_to_sdio_func(wilc->dev);
 	struct wilc_sdio *sdio_priv = wilc->bus_data;
+	if (!sdio_priv) {
+		dev_err(&func->dev, "%s: 'bus_data' not initialized\n", __FUNC__);
+		return -1;
+	}
+
 	u32 reg;
 	int ret, i;
 

--- a/drivers/staging/wilc1000/sdio.c
+++ b/drivers/staging/wilc1000/sdio.c
@@ -221,6 +221,7 @@ dispose_irq:
 	wilc_netdev_cleanup(wilc);
 free:
 	kfree(sdio_priv);
+	wilc->bus_data = NULL;
 	return ret;
 }
 
@@ -235,6 +236,7 @@ static void wilc_sdio_remove(struct sdio_func *func)
 	wilc_netdev_cleanup(wilc);
 	wilc_bt_deinit();
 	kfree(sdio_priv);
+	wilc->bus_data = NULL;
 }
 
 static int wilc_sdio_reset(struct wilc *wilc)

--- a/drivers/staging/wilc1000/spi.c
+++ b/drivers/staging/wilc1000/spi.c
@@ -162,6 +162,7 @@ netdev_cleanup:
 	wilc_netdev_cleanup(wilc);
 free:
 	kfree(spi_priv);
+	wilc->bus_data = NULL;
 	return ret;
 }
 
@@ -176,6 +177,7 @@ static int wilc_bus_remove(struct spi_device *spi)
 	wilc_netdev_cleanup(wilc);
 	wilc_bt_deinit();
 	kfree(spi_priv);
+	wilc->bus_data = NULL;
 	return 0;
 }
 

--- a/drivers/staging/wilc1000/wlan.c
+++ b/drivers/staging/wilc1000/wlan.c
@@ -1550,10 +1550,6 @@ int wilc_wlan_start(struct wilc *wilc)
 	ret = wilc->hif_func->hif_write_reg(wilc, WILC_GLB_RESET_0, reg);
 	wilc->hif_func->hif_read_reg(wilc, WILC_GLB_RESET_0, &reg);
 
-	if (!ret)
-		wilc->initialized = 1;
-	else
-		wilc->initialized = 0;
 	release_bus(wilc, WILC_BUS_RELEASE_ALLOW_SLEEP, DEV_WIFI);
 
 	return (ret < 0) ? ret : 0;

--- a/drivers/staging/wilc1000/wlan.c
+++ b/drivers/staging/wilc1000/wlan.c
@@ -1889,6 +1889,7 @@ int wilc_wlan_init(struct net_device *dev)
 	wilc = vif->wilc;
 
 	wilc->quit = 0;
+	wilc->close = 0;
 
 	PRINT_INFO(vif->ndev, INIT_DBG, "Initializing WILC_Wlan\n");
 


### PR DESCRIPTION
When kree(sdio_priv) we should also null the `bus_data` probably